### PR TITLE
Check and load bbswitch kernel module

### DIFF
--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -67,7 +67,8 @@ COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.c
 
 # --------- TURNING ON GPU -----------
 echo 'Waking up nvidia GPU'
-if ! [ -f /proc/acpi/bbswitch ] then
+if ! [ -f /proc/acpi/bbswitch ] 
+then
   execute "sudo modprobe bbswitch"
 fi
 execute "sudo tee /proc/acpi/bbswitch <<<ON"
@@ -96,7 +97,8 @@ echo 'Unloading nvidia module'
 execute "sudo rmmod nvidia"
 
 # --------- TURNING OFF GPU ----------
-if [ -f /proc/acpi/bbswitch ] then
+if [ -f /proc/acpi/bbswitch ] 
+then
   echo 'Turning off nvidia GPU'
   execute "sudo tee /proc/acpi/bbswitch <<<OFF"
 

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -68,7 +68,7 @@ COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.c
 # --------- TURNING ON GPU -----------
 echo 'Waking up nvidia GPU'
 if ! [ -f /proc/acpi/bbswitch ] then
-  execute sudo modprobe bbswitch
+  execute "sudo modprobe bbswitch"
 fi
 execute "sudo tee /proc/acpi/bbswitch <<<ON"
 

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -67,6 +67,9 @@ COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.c
 
 # --------- TURNING ON GPU -----------
 echo 'Waking up nvidia GPU'
+if ! [ -f /proc/acpi/bbswitch ] then
+  execute sudo modprobe bbswitch
+fi
 execute "sudo tee /proc/acpi/bbswitch <<<ON"
 
 # ---------- LOADING MODULES ----------
@@ -93,8 +96,12 @@ echo 'Unloading nvidia module'
 execute "sudo rmmod nvidia"
 
 # --------- TURNING OFF GPU ----------
-echo 'Turning off nvidia GPU'
-execute "sudo tee /proc/acpi/bbswitch <<<OFF"
+if [ -f /proc/acpi/bbswitch ] then
+  echo 'Turning off nvidia GPU'
+  execute "sudo tee /proc/acpi/bbswitch <<<OFF"
 
-echo -n 'Current state of nvidia GPU: '
-execute "cat /proc/acpi/bbswitch"
+  echo -n 'Current state of nvidia GPU: '
+  execute "cat /proc/acpi/bbswitch"
+else
+  echo "Bbswitch kernel module not loaded."
+fi


### PR DESCRIPTION
In my distribution on boot bbswitch kernel module not loaded,
I add check and modprobe bbswitch if not found /proc/acpi/bbswitch