### PR TITLE
allow execution of files not in path

### DIFF
--- a/nvidia-xinitrc
+++ b/nvidia-xinitrc
@@ -39,6 +39,6 @@ if [ -f "$userxinitrc" ]; then
     sh ${userxinitrc} $#
 else
     if [ $# -gt 0 ]; then
- 		$*
+        "$*"
 	fi
 fi

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -45,14 +45,20 @@ NEWDISP=":$XNUM"
 
 if [ ! -z "$*" ] # generate exec line if arguments are given
 then 
-  # test if executable exists
-  if [ ! -x "$(which $1 2> /dev/null)" ] 
+  # test if executable exists in path
+  if [ -x "$(which $1 2> /dev/null)" ]
   then
+    # generate exec line
+    EXECL="$(which $1)"
+  # test if executable exists on disk
+  elif [ -e "$(realpath "$1")" ]
+  then
+    # generate exec line
+    EXECL="$(realpath "$1")"
+  else
     echo "$1: No such executable!"
     exit 1
   fi
-  # generate exec line
-  EXECL="$(which $1)"
   shift 1
   EXECL="$EXECL $*"
 else # prepare to start new X sessions if no arguments passed


### PR DESCRIPTION
Previously, if the file you wanted to `nvidia-xrun` was not in your path and/or there were spaces in the filename, `nvidia-xrun` would fail.

Specifically, the following command would fail with "No such executable!" until `nvidia-xinitrc` was edited:

* `cd path/to/file\ with && nvidia-xrun ./space`

Next, this command would fail until `nvidia-xrun` was edited:

* `nvidia-xrun path/to/file\ with/space`

Now, both of these commands will work as expected.