### PR TITLE
Add nvidia module path for Fedora

### DIFF
--- a/nvidia-xorg.conf
+++ b/nvidia-xorg.conf
@@ -4,6 +4,7 @@ Section "Files"
   ModulePath "/usr/lib32/nvidia/xorg/modules"
   ModulePath "/usr/lib32/xorg/modules"
   ModulePath "/usr/lib64/nvidia/xorg/modules"
+  ModulePath "/usr/lib64/nvidia/xorg"
   ModulePath "/usr/lib64/xorg/modules"
 EndSection
 


### PR DESCRIPTION
This enables using nvidia-xrun on Fedora Linux. Basically Nvidia drivers (from negativo17 repo) stores Xorg GLX module in /usr/lib64/nvidia/xorg directory instead of /usr/lib64/nvidia/xorg/modules directory like in Arch Linux. Adding Fedora path to ModulePath in nvidia-xorg.conf makes nvidia-xrun works on Fedora.