### PR TITLE
Fixing unloading modules: executing modprobe with -r

### DIFF
--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -98,7 +98,7 @@ execute ${COMMAND}
 for module in "${MODULES_UNLOAD[@]}"
 do
    	echo "Unloading module ${module}"
-	execute "sudo modprobe ${module}"
+	execute "sudo modprobe -r ${module}"
 done
 
 # --------- TURNING OFF GPU ----------


### PR DESCRIPTION
Hello!

It seems like there is a little issue with unloading module logic in nvidia-xrun. 

As i can see it is a typo appeared here https://github.com/Witko/nvidia-xrun/commit/43735003aa38b884251243ec907519ebd68ca471

Thanks.