### PR TITLE
Chg modprobe to rmmod to actually unload module

### DIFF
--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -98,7 +98,7 @@ execute ${COMMAND}
 for module in "${MODULES_UNLOAD[@]}"
 do
    	echo "Unloading module ${module}"
-	execute "sudo modprobe ${module}"
+	execute "sudo rmmod ${module}"
 done
 
 # --------- TURNING OFF GPU ----------


### PR DESCRIPTION
I guess that was changed to modprobe by mistake in the "Removed bbswitch" commit... (43735003aa38b884251243ec907519ebd68ca471)
Am I right ?