### PR TITLE
Add option to control PM and removal behavior

### DIFF
--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -5,6 +5,14 @@
 # output of lshw.
 ENABLE_PM=1
 
+# When PM is enabled, remove the card from the system after the command exists
+# and modules unload: the card will be readded in the next nvidia-xrun
+# execution before loading the nvidia module again. This is recommended as Xorg
+# and some other programs tend to load the nvidia module if they detect a
+# nvidia card in the system, and when the module is loaded the card can't save
+# power.
+REMOVE_DEVICE=1
+
 # Bus ID of the PCI express controller
 CONTROLLER_BUS_ID=0000:00:01.0
 

--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -1,3 +1,10 @@
+# When enabled, nvidia-xrun will turn the card on before attempting to load the
+# modules and running the command, and turn it off after the commands exits and
+# the modules gets unloaded. If order for this to work, CONTROLLER_BUS_ID and
+# DEVICE_BUS_ID must be set correctly. IDs can be found by by inspecting the
+# output of lshw.
+ENABLE_PM=1
+
 # Bus ID of the PCI express controller
 CONTROLLER_BUS_ID=0000:00:01.0
 

--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -1,5 +1,14 @@
+# Bus ID of the PCI express controller
 CONTROLLER_BUS_ID=0000:00:01.0
+
+# Bus ID of the graphic card
 DEVICE_BUS_ID=0000:01:00.0
+
+# Seconds to wait before turning on the card after PCI devices rescan
 BUS_RESCAN_WAIT_SEC=1
+
+# Ordered list of modules to load before running the command
 MODULES_LOAD=(nvidia nvidia_uvm nvidia_modeset "nvidia_drm modeset=1")
+
+# Ordered list of modules to unload after the command exits
 MODULES_UNLOAD=(nvidia_drm nvidia_modeset nvidia_uvm nvidia)

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -26,6 +26,40 @@ function turn_off_gpu {
   execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
 }
 
+function turn_on_gpu {
+  echo 'Turning the PCIe controller on to allow card rescan'
+  execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<on"
+
+  echo 'Waiting 1 second'
+  execute "sleep 1"
+
+  if [[ ! -d /sys/bus/pci/devices/${DEVICE_BUS_ID} ]]; then
+    echo 'Rescanning PCI devices'
+    execute "sudo tee /sys/bus/pci/rescan <<<1"
+    echo "Waiting ${BUS_RESCAN_WAIT_SEC} second for rescan"
+    execute "sleep ${BUS_RESCAN_WAIT_SEC}"
+  fi
+
+  echo 'Turning the card on'
+  execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<on"
+}
+
+function load_modules {
+  for module in "${MODULES_LOAD[@]}"
+  do
+    echo "Loading module ${module}"
+    execute "sudo modprobe ${module}"
+  done
+}
+
+function unload_modules {
+  for module in "${MODULES_UNLOAD[@]}"
+  do
+    echo "Unloading module ${module}"
+    execute "sudo modprobe -r ${module}"
+  done
+}
+
 if [[ "$1" == "-d" ]]
   then
     DRY_RUN=1
@@ -86,38 +120,16 @@ EXECL="/etc/X11/xinit/nvidia-xinitrc \"$EXECL\""
 COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.conf -configdir nvidia-xorg.conf.d"
 
 # --------- TURNING ON GPU -----------
-echo 'Turning the PCIe controller on to allow card rescan'
-execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<on"
-
-echo 'Waiting 1 second'
-execute "sleep 1"
-
-if [[ ! -d /sys/bus/pci/devices/${DEVICE_BUS_ID} ]]; then
-	echo 'Rescanning PCI devices'
-	execute "sudo tee /sys/bus/pci/rescan <<<1"
-	echo "Waiting ${BUS_RESCAN_WAIT_SEC} second for rescan"
-	execute "sleep ${BUS_RESCAN_WAIT_SEC}"
-fi
-
-echo 'Turning the card on'
-execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<on"
+turn_on_gpu
 
 # ---------- LOADING MODULES ----------
-for module in "${MODULES_LOAD[@]}"
-do
-   	echo "Loading module ${module}"
-	execute "sudo modprobe ${module}"
-done
+load_modules
 
 # ---------- EXECUTING COMMAND --------
 execute ${COMMAND}
 
 # ---------- UNLOADING MODULES --------
-for module in "${MODULES_UNLOAD[@]}"
-do
-   	echo "Unloading module ${module}"
-	execute "sudo modprobe -r ${module}"
-done
+unload_modules
 
 # --------- TURNING OFF GPU ----------
 turn_off_gpu

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -120,7 +120,9 @@ EXECL="/etc/X11/xinit/nvidia-xinitrc \"$EXECL\""
 COMMAND="xinit $EXECL -- $NEWDISP vt$LVT -nolisten tcp -br -config nvidia-xorg.conf -configdir nvidia-xorg.conf.d"
 
 # --------- TURNING ON GPU -----------
-turn_on_gpu
+if [[ "$ENABLE_PM" == '1' ]]; then
+  turn_on_gpu
+fi
 
 # ---------- LOADING MODULES ----------
 load_modules
@@ -132,4 +134,6 @@ execute ${COMMAND}
 unload_modules
 
 # --------- TURNING OFF GPU ----------
-turn_off_gpu
+if [[ "$ENABLE_PM" == '1' ]]; then
+  turn_off_gpu
+fi

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -19,8 +19,13 @@ function execute {
 }
 
 function turn_off_gpu {
-  echo 'Removing Nvidia bus from the kernel'
-  execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
+  if [[ "$REMOVE_DEVICE" == '1' ]]; then
+    echo 'Removing Nvidia bus from the kernel'
+    execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
+  else
+    echo 'Enabling powersave for the graphic card'
+    execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<auto"
+  fi
 
   echo 'Enabling powersave for the PCIe controller'
   execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"


### PR DESCRIPTION
This PR:

- moves code into functions to improve readability and reusability
- add comments for the options in `config/nvidia-xrun`
- add a `ENABLE_PM` flag to control whether nvidia-xrun should touch the devices at all
- add a `REMOVE_DEVICE` flag to control whether the card should be removed or simply set in power saving mode