### PR TITLE
Replace sleep BUS_RESCAN_WAIT_SEC with lspci-based GPU check; tweak MODULES_LOAD in config

### DIFF
--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -19,11 +19,14 @@ CONTROLLER_BUS_ID=0000:00:01.0
 # Bus ID of the graphic card
 DEVICE_BUS_ID=0000:01:00.0
 
-# Seconds to wait before turning on the card after PCI devices rescan
-BUS_RESCAN_WAIT_SEC=1
-
 # Ordered list of modules to load before running the command
-MODULES_LOAD=(nvidia nvidia_uvm nvidia_modeset "nvidia_drm modeset=1")
+# >>>>> ORIGINAL
+#MODULES_LOAD=(nvidia nvidia_uvm nvidia_modeset "nvidia_drm modeset=1")
+
+# >>>>> MASSKONFUZION: "nvidia_drm modeset=1" seems to cause sporadic general
+# protection faults on my machine. At a minimum, perhaps the "modeset=1"
+# option can be documented as a parameter to tweak?
+MODULES_LOAD=(nvidia nvidia_uvm nvidia_modeset nvidia_drm)
 
 # Ordered list of modules to unload after the command exits
 MODULES_UNLOAD=(nvidia_drm nvidia_modeset nvidia_uvm nvidia)

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -41,8 +41,27 @@ function turn_on_gpu {
   if [[ ! -d /sys/bus/pci/devices/${DEVICE_BUS_ID} ]]; then
     echo 'Rescanning PCI devices'
     execute "sudo tee /sys/bus/pci/rescan <<<1"
-    echo "Waiting ${BUS_RESCAN_WAIT_SEC} second for rescan"
-    execute "sleep ${BUS_RESCAN_WAIT_SEC}"
+
+    # >>>>> MASSKONFUZION: This comment for review; feel free to delete:
+    # This change proposes to do away with BUS_RESCAN_WAIT_SEC, in favor of
+    # waiting for the NVIDIA GPU to appear in lspci. The code, as written,
+    # assumes the GPU will appear. But perhaps a more robust solution (not
+    # implemented as of yet) would be to fail if the GPU does not appear
+    # after a given timeout interval.
+    if [[ ${DRY_RUN} -eq 1 ]]; then
+        echo '>> Dry run. Waiting for NVIDIA video device'
+    else
+        echo 'Waiting for NVIDIA video device'
+        RESULT="1"
+        while [[ ${RESULT} -ne 0 ]]; do
+            echo -n '.'
+            lspci | grep -v Audio | grep NVIDIA > /dev/null
+            RESULT=$?
+            sleep 1
+        done
+        echo 'Woo-hoo! Got it :fist pump:'
+        lspci | grep -v Audio | grep NVIDIA
+    fi
   fi
 
   echo 'Turning the card on'
@@ -54,6 +73,7 @@ function load_modules {
   do
     echo "Loading module ${module}"
     execute "sudo modprobe ${module}"
+    sleep 1
   done
 }
 
@@ -62,6 +82,7 @@ function unload_modules {
   do
     echo "Unloading module ${module}"
     execute "sudo modprobe -r ${module}"
+    sleep 1
   done
 }
 


### PR DESCRIPTION
@Witko et. al, I really love what you're doing with nvidia-xrun.  This PR is the result of my playing around with the script & configs on my machine, trying to get things to work.

Background: I was getting sporadic general protection faults when running nvidia-xrun "as-is" from Git on my machine.  Some salient specs:
* Form factor: laptop
* OS: ```Arch Linux (kernel: 5.2.9-arch1-1-ARCH)``` (of course, with Arch being a rolling release distro, the kernel updates _all the time_...)
* GPUs:
  * `Intel Corporation 2nd Generation Core Processor Family Integrated Graphics Controller (rev 09)`
  * `NVIDIA Corporation GF119M [NVS 4200M] (rev a1)` (`nvidia-390xx` driver -- this driver seems to get updates surprisingly frequently, as well, for a legacy driver)
* CPU: ```Intel(R) Core(TM) i7-2760QM CPU @ 2.40GHz```
* RAM: 8 GB
so, not a super high-powered machine, by any stretch.. but still capable.

Originally, I had been using the nvidia-xrun package from the Arch AUR, until it started to fail on me sporadicatlly.  I then noticed that the AUR package was flagged out of date as of roughly a month ago, so I cloned the git repo to get the latest.

After deploying the scripts & configs manually from git, I was still getting sporadic GP faults.  That led me to tinker.

I now seem to be able to start nvidia-xrun.  I think the main issue was the nvidia_drm "modeset" option.  But to be honest, I'm still not 100% sure of the interplay between, for example, `nvidia_modeset` and `nvidia_drm modeset=1` vs. `nvidia_drm` with the modeset option omitted..

The other changes in this PR were maybe not strictly necessary.  But as I was troubleshooting, I came to like the idea of using an lspci-based verification that the GPU came up, instead of the sleep-based approach.  (My rationale was:  I added sleeps/slowdowns, thinking maybe the GP faults were caused by a race condition of some sort -- that was the first thing I thought of to explain why _sometimes_ nvidia-xrun would start my x session and window manager just fine, but other times it wouldn't.  Truth told, I still can't explain it... ¯\_(ツ)_/¯ )

Any feedback is welcome.