### PR TITLE
Implement USE_BBSWITCH option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ sudo dnf install nvidia-xrun
 ```
 
 ## Troubleshooting
+
 ### Steam issues
 Yes unfortunately running Steam directly with nvidia-xrun does not work well - I recommend to use some window manager like openbox.
 
@@ -105,6 +106,10 @@ To fix, you can change the DPI settings in `~/.Xresources (~/.Xdefaults)` file b
 ```
 Xft.dpi: 192
 ```
+
+### Crashing during when unloading nvidia modules
+
+Try set `USE_BBSWITCH=1`, you'll have to install `bbswitch` manually as well.
 
 ### `nouveau` driver conflict
 `nouveau` driver should be automatically blacklisted by `nvidia` but in case it is not, `nvidia` might not get access to GPU. Then you need to manually blacklist `nouveau` following Arch wiki https://wiki.archlinux.org/index.php/kernel_modules#Blacklisting.

--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -11,7 +11,15 @@ ENABLE_PM=1
 # and some other programs tend to load the nvidia module if they detect a
 # nvidia card in the system, and when the module is loaded the card can't save
 # power.
+#
+# USE_BBSWITCH option below can override the behavior of this option.
 REMOVE_DEVICE=1
+
+# When enabled, nvidia-xrun will toggle power for the card using bbswitch.
+# This *requires* bbswitch to be installed.
+#
+# Note that this option overrides REMOVE_DEVICE paramter above when enabled.
+USE_BBSWITCH=0
 
 # Bus ID of the PCI express controller
 CONTROLLER_BUS_ID=0000:00:01.0

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -19,34 +19,44 @@ function execute {
 }
 
 function turn_off_gpu {
-  if [[ "$REMOVE_DEVICE" == '1' ]]; then
-    echo 'Removing Nvidia bus from the kernel'
-    execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
+  if [[ "$USE_BBSWITCH" == '1' ]]; then
+    echo 'Turning off GPU using bbswitch '
+    execute "sudo tee /proc/acpi/bbswitch <<<'OFF'"
   else
-    echo 'Enabling powersave for the graphic card'
-    execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<auto"
-  fi
+    if [[ "$REMOVE_DEVICE" == '1' ]]; then
+      echo 'Removing Nvidia bus from the kernel'
+      execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/remove <<<1"
+    else
+      echo 'Enabling powersave for the graphic card'
+      execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<auto"
+    fi
 
-  echo 'Enabling powersave for the PCIe controller'
-  execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
+    echo 'Enabling powersave for the PCIe controller'
+    execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
+  fi
 }
 
 function turn_on_gpu {
-  echo 'Turning the PCIe controller on to allow card rescan'
-  execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<on"
+  if [[ "$USE_BBSWITCH" == '1' ]]; then
+    echo 'Turning on GPU using bbswitch '
+    execute "sudo tee /proc/acpi/bbswitch <<<'ON'"
+  else
+    echo 'Turning the PCIe controller on to allow card rescan'
+    execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<on"
 
-  echo 'Waiting 1 second'
-  execute "sleep 1"
+    echo 'Waiting 1 second'
+    execute "sleep 1"
 
-  if [[ ! -d /sys/bus/pci/devices/${DEVICE_BUS_ID} ]]; then
-    echo 'Rescanning PCI devices'
-    execute "sudo tee /sys/bus/pci/rescan <<<1"
-    echo "Waiting ${BUS_RESCAN_WAIT_SEC} second for rescan"
-    execute "sleep ${BUS_RESCAN_WAIT_SEC}"
+    if [[ ! -d /sys/bus/pci/devices/${DEVICE_BUS_ID} ]]; then
+      echo 'Rescanning PCI devices'
+      execute "sudo tee /sys/bus/pci/rescan <<<1"
+      echo "Waiting ${BUS_RESCAN_WAIT_SEC} second for rescan"
+      execute "sleep ${BUS_RESCAN_WAIT_SEC}"
+    fi
+
+    echo 'Turning the card on'
+    execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<on"
   fi
-
-  echo 'Turning the card on'
-  execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<on"
 }
 
 function load_modules {


### PR DESCRIPTION
On my system, both methods crash and do not turn off GPU correctly (it stays on, despite being not even visible in `lspci`). Other times it even causes `tee` to become a zombie process using 100% of CPU forever, making me have to restart my entire machine.

After some trial and error, `bbswitch` seemed to be the only stable and working solution. The `turn_off_gpu.sh` script bundled with `acpid` didn't work either.

Thus, I implemented this feature and tested it on my machine, so far it works flawlessly without issues.