### PR TITLE
Re-introduction of bbswitch

### DIFF
--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -13,6 +13,10 @@ ENABLE_PM=1
 # power.
 REMOVE_DEVICE=1
 
+# If you getting trouble with ENABLE_PM=1 or your dGPU doesn't go off with either
+# ENABLE_PM 1 or 0 set this to 1
+USE_BBSWITCH=0
+
 # Bus ID of the PCI express controller
 CONTROLLER_BUS_ID=0000:00:01.0
 

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -65,6 +65,11 @@ function unload_modules {
   done
 }
 
+function bbswitch_off {
+  echo "Turning card OFF with bbswitch"
+  execute "sudo tee /proc/acpi/bbswitch <<<OFF"
+}
+
 if [[ "$1" == "-d" ]]
   then
     DRY_RUN=1
@@ -137,6 +142,10 @@ execute ${COMMAND}
 
 # ---------- UNLOADING MODULES --------
 unload_modules
+
+if [[ "$USE_BBSWITCH" == '1' ]]; then
+  bbswitch_off
+fi
 
 # --------- TURNING OFF GPU ----------
 if [[ "$ENABLE_PM" == '1' ]]; then


### PR DESCRIPTION
On some hardware PM doesn't work as expected and card never goes off
or goes on by itself thus an optional bbswitch is introduced.

* Added config `USE_BBSWITCH` to config
* Added function to turn off dGPU with bbswitch