### PR TITLE
Do not append CWD to (empty) LD_LIBRARY_PATH

### DIFF
--- a/nvidia-xinitrc
+++ b/nvidia-xinitrc
@@ -24,7 +24,7 @@ if [[ -f "$usermodmap" ]]; then
     xmodmap "$usermodmap"
 fi
 
-export LD_LIBRARY_PATH=/usr/lib64/nvidia/:/usr/lib32/nvidia:/usr/lib:${LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=/usr/lib64/nvidia/:/usr/lib32/nvidia:/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 
 # load additional configs
 if [[ -d /etc/X11/xinit/nvidia-xinitrc.d ]] ; then


### PR DESCRIPTION
If LD_LIBRARY_PATH is unset, nvidia-xinitrc exports LD_LIBRARY_PATH with
a trailing colon (':') which is interpreted as an empty path, i.e., the
current working directory (CWD). This creates a security vulnerability
known as "Uncontrolled Search Path Element" (CWE-427). The commit avoids
appending a trailing colon if LD_LIBRARY_PATH is empty.