### PR TITLE
Potential Fix: lockups with HD Audio controller

### DIFF
--- a/config/nvidia-xrun
+++ b/config/nvidia-xrun
@@ -16,6 +16,14 @@ REMOVE_DEVICE=1
 # Bus ID of the PCI express controller
 CONTROLLER_BUS_ID=0000:00:01.0
 
+# Turning the PCIe controller on when the HD audio controller is turned off
+# can lead to hung tee processes, hung kernel tasks and total system lockups.
+# If HDA_CONTROLLER_BUS_ID is set to the Bus ID of the NVIDIA HD audio controller
+# it will be turned on before the PCIe controller is.
+#
+# Bus ID of the HD audio controller
+#HDA_CONTROLLER_BUS_ID=0000:01:00.1
+
 # Bus ID of the graphic card
 DEVICE_BUS_ID=0000:01:00.0
 

--- a/nvidia-xrun
+++ b/nvidia-xrun
@@ -27,11 +27,24 @@ function turn_off_gpu {
     execute "sudo tee /sys/bus/pci/devices/${DEVICE_BUS_ID}/power/control <<<auto"
   fi
 
+  if [ -n "$HDA_CONTROLLER_BUS_ID" ]; then
+    echo 'Enabling powersave for the HD audio controller'
+    execute "sudo tee /sys/bus/pci/devices/${HDA_CONTROLLER_BUS_ID}/power/control <<<auto"
+  fi
+
   echo 'Enabling powersave for the PCIe controller'
   execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<auto"
 }
 
 function turn_on_gpu {
+
+  if [ -n "$HDA_CONTROLLER_BUS_ID" ]; then
+    echo 'Turning on the HD audio controller:'
+    echo "  This may throw a pci_err: \"can't change power state [...] (config space inaccessible)\""
+    echo "  But it can avoid some lockups. "
+    execute "sudo tee /sys/bus/pci/devices/${HDA_CONTROLLER_BUS_ID}/power/control <<<on"
+  fi
+
   echo 'Turning the PCIe controller on to allow card rescan'
   execute "sudo tee /sys/bus/pci/devices/${CONTROLLER_BUS_ID}/power/control <<<on"
 


### PR DESCRIPTION
Turning the PCIe controller on before the HD audio controller is turned on
can lead to a hung tee processes, hung kernel tasks and other badness.

This introduces HDA_CONTROLLER_BUS_ID to the config
which if set will turn HD Audio Controller on
_before_ the PCIe controller is turned on.
While this can cause a PCI error:
```
pci 0000:01:00.1: can't change power state from D3cold to D0 (config space inaccessible)
```
that's a lot better than hanging the system.

When turning off the cards the order doesn't seem to matter,
but we do need to turn Powersave for Both so that the card 
actually turns off (Powertop reports ~10 Watts less draw).

**I have no Idea why this works**. 
So I can't say for certain *that* it works.
But It could be the fix for a few of the issues mentioned in  #137 

If you have similar hangs please test this.
Especially if you get something similar to me in `lspci -tvv`
```
-[0000:00]-+ ...
           +-01.0-[01]--+-00.0  NVIDIA Corporation GP104BM [GeForce GTX 1070 Mobile]
           |            \-00.1  NVIDIA Corporation GP104 High Definition Audio Controller
```
or `lspci`
```
00:01.0 PCI bridge: Intel Corporation 6th-10th Gen Core Processor PCIe Controller (x16) (rev 05)
01:00.0 VGA compatible controller: NVIDIA Corporation GP104BM [GeForce GTX 1070 Mobile] (rev a1)
01:00.1 Audio device: NVIDIA Corporation GP104 High Definition Audio Controller (rev a1)
```